### PR TITLE
Multiple Nagios server concurrency fix

### DIFF
--- a/check_bandwidth.sh
+++ b/check_bandwidth.sh
@@ -4,7 +4,7 @@ INTERVAL="1"  # update interval in seconds
 
 if [ -z "$1" ]; then
         echo
-        echo "example: plugin.sh HOSTNAME system interface_name time warning_mbit/s critical_mbit/s total mbit/s;" 
+        echo "example: plugin.sh HOSTNAME system interface_name time warning_mbit/s critical_mbit/s total mbit/s;"
         echo
         echo "./check_bandwidth.sh localhost linux eth0 15 80 90 100"
         echo "./check_bandwidth.sh switchname cisco GigabitEthernet0/1 15 80 90 100 192.192.192.192 snmp-community"
@@ -32,10 +32,10 @@ bin_wc=`which wc`
 bin_awk=`which awk`
 bin_snmpwalk=`which snmpwalk`
 interfaces_oid=1.3.6.1.2.1.2.2.1.2
-                                                                                                                                                                        
-                                                                                                                                                                        
-if [ "$system" = "cisco" ];                                                                                                                                             
-    then                                                                                                                                                                
+
+
+if [ "$system" = "cisco" ];
+	then
         if_index=`$bin_snmpwalk -c $community -v 2c $ip $interfaces_oid | grep $IF | sed 's/^.*\.//;s/\ .*$//'`
         pidfile=/tmp/"$name"_"$if_index"_check_bandwidth.pid
 fi
@@ -174,7 +174,7 @@ elif [ "$system" = "cisco" ];
             do
                 rx_now=`$bin_snmpwalk -c $community -v 2c -Oqv $ip 1.3.6.1.2.1.2.2.1.10.$if_index`
                     if [ $rx_now -ge $rx_old ];
-                        then 
+                        then
                         rx_tag=1
                             if [ $rx_now -gt $rx_old ];
                                 then
@@ -186,7 +186,7 @@ elif [ "$system" = "cisco" ];
                 rx_old=$rx_now
                 tx_now=`$bin_snmpwalk -c $community -v 2c -Oqv $ip 1.3.6.1.2.1.2.2.1.16.$if_index`
                     if [ $tx_now -ge $tx_old ];
-                        then 
+                        then
                         tx_tag=1
                             if [ $tx_now -gt $tx_old ];
                                 then

--- a/check_bandwidth.sh
+++ b/check_bandwidth.sh
@@ -37,11 +37,11 @@ interfaces_oid=1.3.6.1.2.1.2.2.1.2
 if [ "$system" = "cisco" ];
 	then
         if_index=`$bin_snmpwalk -c $community -v 2c $ip $interfaces_oid | grep $IF | sed 's/^.*\.//;s/\ .*$//'`
-        pidfile=/tmp/"$name"_"$if_index"_check_bandwidth.pid
+        pidfile=/tmp/"$name"_"$if_index"_check_bandwidth_"$current_pid".pid
 fi
 if [ "$system" = "linux" ];
     then
-        pidfile=/tmp/"$name"_"$IF"_check_bandwidth.pid
+        pidfile=/tmp/"$name"_"$IF"_check_bandwidth_"$current_pid".pid
 fi
 
 if [ -f $pidfile ];
@@ -54,21 +54,21 @@ fi
 
 if [ "$system" = "linux" ];
     then
-        tmpfile_rx=/tmp/"$name"_"$IF"_check_bandwidth_rx.tmp
-        tmpfile_tx=/tmp/"$name"_"$IF"_check_bandwidth_tx.tmp
-        reverse_tmpfile_rx=/tmp/"$name"_"$IF"_reverse_check_bandwidth_rx.tmp
-        reverse_tmpfile_tx=/tmp/"$name"_"$IF"_reverse_check_bandwidth_tx.tmp
-        deltafile_rx=/tmp/"$name"_"$IF"_delta_check_bandwidth_rx.tmp
-        deltafile_tx=/tmp/"$name"_"$IF"_delta_check_bandwidth_tx.tmp
+        tmpfile_rx=/tmp/"$name"_"$IF"_check_bandwidth_rx_"$current_pid".tmp
+        tmpfile_tx=/tmp/"$name"_"$IF"_check_bandwidth_tx_"$current_pid".tmp
+        reverse_tmpfile_rx=/tmp/"$name"_"$IF"_reverse_check_bandwidth_rx_"$current_pid".tmp
+        reverse_tmpfile_tx=/tmp/"$name"_"$IF"_reverse_check_bandwidth_tx_"$current_pid".tmp
+        deltafile_rx=/tmp/"$name"_"$IF"_delta_check_bandwidth_rx_"$current_pid".tmp
+        deltafile_tx=/tmp/"$name"_"$IF"_delta_check_bandwidth_tx_"$current_pid".tmp
 elif [ "$system" = "cisco" ];
     then
-        tmpfile_rx=/tmp/"$name"_"$if_index"_check_bandwidth_rx.tmp
-        tmpfile_tx=/tmp/"$name"_"$if_index"_check_bandwidth_tx.tmp
-        reverse_tmpfile_rx=/tmp/"$name"_"$if_index"_reverse_check_bandwidth_rx.tmp
-        reverse_tmpfile_tx=/tmp/"$name"_"$if_index"_reverse_check_bandwidth_tx.tmp
-        deltafile_rx=/tmp/"$name"_"$if_index"_delta_check_bandwidth_rx.tmp
-        deltafile_tx=/tmp/"$name"_"$if_index"_delta_check_bandwidth_tx.tmp
-        laststate_file=/tmp/"$name"_"$if_index"_laststate.tmp
+        tmpfile_rx=/tmp/"$name"_"$if_index"_check_bandwidth_rx_"$current_pid".tmp
+        tmpfile_tx=/tmp/"$name"_"$if_index"_check_bandwidth_tx_"$current_pid".tmp
+        reverse_tmpfile_rx=/tmp/"$name"_"$if_index"_reverse_check_bandwidth_rx_"$current_pid".tmp
+        reverse_tmpfile_tx=/tmp/"$name"_"$if_index"_reverse_check_bandwidth_tx_"$current_pid".tmp
+        deltafile_rx=/tmp/"$name"_"$if_index"_delta_check_bandwidth_rx_"$current_pid".tmp
+        deltafile_tx=/tmp/"$name"_"$if_index"_delta_check_bandwidth_tx_"$current_pid".tmp
+        laststate_file=/tmp/"$name"_"$if_index"_laststate_"$current_pid".tmp
 fi
 
 warn_kbits=`$bin_expr $warn '*' 1000000`


### PR DESCRIPTION
This commit fixes a concurrency problem that occurs when calling
from multiple nagios servers. It adds the script's PID number to
all temporary file names used so that running the script again
before any previous runs complete cannot cause a problem.

The problem was most noticeable when a second call to the script
resulted in a collision on the PID lock file check resulting in
the end user seeing the "need to reduce the check duration or
increase the interval between checks" error message even though
the issue was not the duration or frequency of the checks but the
fact that a check from a different nagios server had a scheduling
collision.

It is possible, but highly unlikely, that multiple runs could
become concurrent in a way that would allow the PID lock file
check to pass yet still allow a file use collision that would
produce bad data.